### PR TITLE
Fixed up npm script and README to not assume globally installed gulp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install all the dependencies:
 Load the starterkits, if any, for instance:
 
     $ npm install starterkit-mustache-demo
-    $ gulp patternlab:loadstarterkit --kit=starterkit-mustache-demo
+    $ npm run gulp -- patternlab:loadstarterkit --kit=starterkit-mustache-demo
 
 Run the project:
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "start": "gulp patternlab:serve",
     "postinstall": "node scripts/postinstall.js",
-    "gulp": "gulp -- ",
+    "gulp": "gulp",
     "stylelint": "stylelint source/sass/**/*.scss"
   },
   "license": "MIT",


### PR DESCRIPTION
The README instructions for loading a starterkit included running `gulp` directly from the command line, but that only works if `gulp-cli` was globally installed.

NPM scripts provide a convenient way to run commands that packages have installed locally in your project under `node_modules/.bin/`, so I've updated the instructions to use that instead.

I had to fix a small bug in `package.json` for this to work properly as well. Including the `--` (which separates command-line args for `npm run` itself from args that are passed to whatever script is being run) in the `package.json` does not work, so I've removed it.

See https://docs.npmjs.com/cli/run-script for more info.