### PR TITLE
Made SASS build output to dist/css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@ patternlab.json
 Thumbs.db
 .idea/
 public
-
-# ignore the generated CSS
-source/css/style.css

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,7 +43,7 @@ gulp.task('pl-sass', function () {
     .pipe(sass(sassOptions).on('error', sass.logError))
     .pipe(autoprefixer())
     .pipe(sourcemaps.write())
-    .pipe(gulp.dest(path.resolve(paths().source.css)))
+    .pipe(gulp.dest(path.resolve(paths().public.css)))
 })
 
 /******************************************************
@@ -234,7 +234,7 @@ function watch() {
       name: 'SASS',
       paths: [normalizePath(paths().source.sass, '**', '*.scss')],
       config: { awaitWriteFinish: true },
-      tasks: gulp.series('pl-sass')
+      tasks: gulp.series('pl-sass', reloadCSS)
     },
     {
       name: 'CSS',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,13 +79,6 @@ gulp.task('pl-copy:assets', function () {
     .pipe(gulp.dest(normalizePath(paths().public.assets)));
 });
 
-// CSS Copy base style
-gulp.task('pl-copy:css:style', function () {
-  return gulp.src(normalizePath(paths().source.css) + '/style.css*')
-    .pipe(gulp.dest(normalizePath(paths().public.css)))
-    .pipe(browserSync.stream());
-});
-
 // CSS Concat and copy pattern-scaffolding
 gulp.task('pl-copy:css:scaffolding', function () {
   return gulp.src(normalizePath(paths().source.css) + '/*pattern-scaffolding*.css')
@@ -155,7 +148,6 @@ gulp.task('pl-assets', gulp.series(
     'pl-copy:favicon',
     'pl-copy:font',
     'pl-sass',
-    'pl-copy:css:style',
     'pl-copy:css:scaffolding',
     'pl-copy:styleguide',
     'pl-copy:styleguide-css'
@@ -237,10 +229,10 @@ function watch() {
       tasks: gulp.series('pl-sass', reloadCSS)
     },
     {
-      name: 'CSS',
-      paths: [normalizePath(paths().source.css, '**', '*.css')],
+      name: 'Pattern Scaffolding CSS',
+      paths: [normalizePath(paths().source.css, '**', '*pattern-scaffolding*.css')],
       config: { awaitWriteFinish: true },
-      tasks: gulp.series(['pl-copy:css:style', 'pl-copy:css:scaffolding'], reloadCSS)
+      tasks: gulp.series('pl-copy:css:scaffolding', reloadCSS)
     },
     {
       name: 'Styleguide Files',


### PR DESCRIPTION
At the moment, SASS files under `source/sass/` are built to `source/css/` (and, if using the dev server, PL's CSS copy task then copies them from there to `public/css/`).

This feels brittle:
* Usually, builds don't output anything under your source dirs, so this is feels counter-intuitive
* Currently `public/css/style.css` is ignored via `.gitignore` - presumably to prevent accidental commits of the build output. However, if someone were to create additional SASS files under `source/sass/` that are _not_ called `style.scss` they'd get built but then not actually copied to the `public/`

This PR therefore:
* Makes the `pl-sass` gulp task output to `public/css/`
* Removes `pl-copy:css:style` gulp task, since it's no longer needed
* Updates `.gitignore`, so that `public/css/style.css` is no longer ignored